### PR TITLE
remove includes for Mac OSX compatibility

### DIFF
--- a/INSTALL_NOTES.txt
+++ b/INSTALL_NOTES.txt
@@ -1,0 +1,11 @@
+# Additional install notes:
+
+# set RAVEROOT environment variable:
+export RAVEROOT=/opt/baltrad
+
+# compile
+make
+
+# install
+# note that as super user the RAVEROOT environment variable is no longer available, so have to add it again
+sudo make install RAVEROOT=/opt/baltrad

--- a/INSTALL_NOTES.txt
+++ b/INSTALL_NOTES.txt
@@ -1,6 +1,7 @@
 # Additional install notes:
 
 # set RAVEROOT environment variable, for example if rave installed in /opt/baltrad/rave:
+# NOTE: leave out the rave folder itself, it has to be the parent directory!!
 export RAVEROOT=/opt/baltrad
 
 # compile

--- a/INSTALL_NOTES.txt
+++ b/INSTALL_NOTES.txt
@@ -1,6 +1,6 @@
 # Additional install notes:
 
-# set RAVEROOT environment variable:
+# set RAVEROOT environment variable, for example if rave installed in /opt/baltrad/rave:
 export RAVEROOT=/opt/baltrad
 
 # compile

--- a/src/iris2list.c
+++ b/src/iris2list.c
@@ -30,9 +30,6 @@ along with RAVE.  If not, see <http://www.gnu.org/licenses/>.
 #include <unistd.h>
 #include <string.h> //strtok_s, memcpy
 #include <sys/types.h>
-#include <error.h>
-#include <argp.h>
-#include <argz.h>
 #include <time.h>
 #include "iris2odim.h" // this includes rave_alloc and other rave related
 #include "iris2list_listobj.h"

--- a/src/iris2odim.c
+++ b/src/iris2odim.c
@@ -1226,6 +1226,14 @@ int populateObject(RaveCoreObject* object, file_element_s* file_element_p) {
       file_element_p->product_header_p->end.site_name);
    if(ncopied > 0 ) rltrim(sname);
    source = mapSource2Nod(sname);
+   /* add site_name as RAD identifier if lookup by mapSource1Nod fails */
+   char source_missing[50];
+   if(strcmp(source,"NOD:xxxxx,PLC:Unknown")==0){
+      strcpy(source_missing,"RAD:");
+      strcat(source_missing,sname);
+      strcat(source_missing,",NOD:xxxxx,PLC:Unknown");
+      source=source_missing;
+   }
    /*
     * The top-level 'what' group has a time and date that are referred to
     * in the OPERA Data Information Model for HDF as 'Nominal' date and time.


### PR DESCRIPTION
Removing these three header files (which do not seem to be used by the repo) fixes compilation on Mac OSX