### PR TITLE
Merge of iris2odim fork which is Python 2 & 3 compatible.

### DIFF
--- a/modules/pyiris2odim.c
+++ b/modules/pyiris2odim.c
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------
-Copyright (C) 2015 The Crown (i.e. Her Majesty the Queen in Right of Canada)
+Copyright (C) 2020 The Crown (i.e. Her Majesty the Queen in Right of Canada)
 
 This file is an add-on to RAVE.
 
@@ -21,8 +21,10 @@ along with RAVE.  If not, see <http://www.gnu.org/licenses/>.
  * @file
  * @author Daniel Michelson, Environment Canada
  * @date 2015-10-28
+ * @author Peter Rodriguez, Environment Canada
+ * @date 2020-09-01, upgrade to use Python >2.6 and Python 3 compatibility file
  */
-#include "Python.h"
+#include "pyiris2odim_compat.h"
 #include "arrayobject.h"
 #include "rave.h"
 #include "rave_debug.h"
@@ -142,21 +144,29 @@ static struct PyMethodDef _iris2odim_functions[] =
 /**
  * Initialize the _iris2odim module
  */
-PyMODINIT_FUNC init_iris2odim(void)
+MOD_INIT(_iris2odim)
 {
-  PyObject* m;
-  m = Py_InitModule("_iris2odim", _iris2odim_functions);
-  ErrorObject = PyString_FromString("_iris2odim.error");
-
-  if (ErrorObject == NULL || PyDict_SetItemString(PyModule_GetDict(m),
-                                                  "error", ErrorObject) != 0) {
-    Py_FatalError("Can't define _iris2odim.error");
+  PyObject* module = NULL;
+  PyObject* dictionary = NULL;
+  
+  MOD_INIT_DEF(module, "_iris2odim", NULL/*doc*/, _iris2odim_functions);
+  if (module == NULL) {
+    return MOD_INIT_ERROR;
   }
+
+  dictionary = PyModule_GetDict(module);
+  ErrorObject = PyErr_NewException("_iris2odim.error", NULL, NULL);
+  if (ErrorObject == NULL || PyDict_SetItemString(dictionary, "error", ErrorObject) != 0) {
+    Py_FatalError("Can't define _iris2odim.error");
+    return MOD_INIT_ERROR;
+  }
+
   import_pyraveio();
   import_pypolarvolume();
   import_pypolarscan();
   import_array(); /*To make sure I get access to numpy*/
   PYRAVE_DEBUG_INITIALIZE;
+  return MOD_INIT_SUCCESS(module);
 }
 
 /*@} End of Module setup */

--- a/modules/pyiris2odim_compat.h
+++ b/modules/pyiris2odim_compat.h
@@ -1,0 +1,143 @@
+/* --------------------------------------------------------------------
+Copyright (C) 2016 Swedish Meteorological and Hydrological Institute, SMHI,
+
+This file has been taken from RAVE for IRIS2ODIM.
+
+RAVE is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+RAVE is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with RAVE.  If not, see <http://www.gnu.org/licenses/>.
+------------------------------------------------------------------------*/
+/**
+ * Python compability file for making it possible to compile iris2odim for both Python >2.6 and Python3
+ * @file
+ * @author Anders Henja (Swedish Meteorological and Hydrological Institute, SMHI)
+ * @date 2010-03-30
+ */
+
+/* Define this to ensure that we are not using old API:s from Numpy. However, for now we are more interested in getting the
+ * code to build on both 2.7 and 3.x
+ */
+/*
+ * #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+ */
+#include "Python.h"
+
+#ifndef PYIRIS2ODIMCOMPAT_H
+#define PYIRIS2ODIMCOMPAT_H
+
+
+#ifndef PyInt_Check
+#define PyInt_Check             PyLong_Check
+#define PyInt_FromLong          PyLong_FromLong
+#define PyInt_AsLong            PyLong_AsLong
+#define PyInt_Type              PyLong_Type
+#endif
+
+#ifndef PyString_Check
+#define PyString_Check          PyUnicode_Check
+#define PyString_AsString       PyUnicode_AsUTF8
+#define PyString_FromString     PyUnicode_FromString
+#define PyString_FromFormat     PyUnicode_FromFormat
+#endif
+
+#if PY_MAJOR_VERSION >= 3
+#define PY_RAVE_ATTRO_NAME_TO_STRING PyUnicode_AsUTF8
+
+#else
+#define PY_RAVE_ATTRO_NAME_TO_STRING PyString_AsString
+
+#endif
+
+#define PY_COMPARE_ATTRO_NAME_WITH_STRING(ptr, name) PyIRIS2ODIMAPI_CompareWithASCIIString(ptr, name)
+
+#define PY_COMPARE_STRING_WITH_ATTRO_NAME(name, ptr) PyIRIS2ODIMAPI_CompareWithASCIIString(ptr, name)
+
+#if PY_MAJOR_VERSION >= 3
+#define MOD_INIT_ERROR        NULL
+#define MOD_INIT_SUCCESS(val) val
+#define MOD_INIT(name)        PyMODINIT_FUNC PyInit_##name(void)
+#define MOD_INIT_DEF(ob, name, doc, methods) \
+  static struct PyModuleDef moduledef = { \
+    PyModuleDef_HEAD_INIT, name, doc, -1, methods, }; \
+    ob = PyModule_Create(&moduledef);
+
+#define MOD_INIT_CREATE_CAPI(ptr, name) PyCapsule_New(ptr, name, NULL)
+#define MOD_INIT_IS_CAPI(ptr) PyCapsule_CheckExact(ptr)
+#define MOD_INIT_GET_CAPI(ptr, name) PyCapsule_GetPointer(ptr, name)
+#define MOD_INIT_SETUP_TYPE(itype, otype) Py_TYPE(&itype) = otype
+#define MOD_INIT_VERIFY_TYPE_READY(type) if (PyType_Ready(type) < 0) return MOD_INIT_ERROR
+
+#else
+#define MOD_INIT_ERROR
+#define MOD_INIT_SUCCESS(val)
+#define MOD_INIT(name) void init##name(void)
+#define MOD_INIT_DEF(ob, name, doc, methods) \
+  ob = Py_InitModule3(name, methods, doc);
+#define MOD_INIT_CREATE_CAPI(ptr, name) PyCObject_FromVoidPtr(ptr, name)
+#define MOD_INIT_IS_CAPI(ptr) PyCObject_Check(ptr)
+#define MOD_INIT_GET_CAPI(ptr, name) PyCObject_AsVoidPtr(ptr)
+#define MOD_INIT_SETUP_TYPE(itype, otype) itype.ob_type = otype
+#define MOD_INIT_VERIFY_TYPE_READY(type)
+#endif
+
+/**
+ * Macros that can be used to simplify way of generating __dir__ content that is necessary for executing dir() on an object
+ */
+#define MOD_DIR_FORWARD_DECLARE(name) static PyObject* _##name##__dir__(name *self)
+
+#define MOD_DIR_REFERENCE(name) _##name##__dir__
+
+#define MOD_DIR_APPEND(list, str)                               \
+  do {                                            \
+    PyObject *o = PyUnicode_FromString(str);        \
+    if (o != NULL)                          \
+      PyList_Append(list, o);         \
+    Py_XDECREF(o);                          \
+  } while (0)
+
+#define MOD_DIR_FUNCTION(name, method_listing) static PyObject * _##name##__dir__(name *self) { \
+  int i=0; \
+  PyObject* rc = PyList_New(0); \
+  if (!rc) \
+    return NULL; \
+\
+  while (method_listing[i].ml_name != NULL) { \
+    MOD_DIR_APPEND(rc, method_listing[i++].ml_name); \
+  } \
+\
+  return rc; \
+}
+
+/**
+ * Tests if a python object string (or unicode) is equal to name.
+ * @param[in] ptr - the python string or unicode
+ * @param[in] name - the string to compare with
+ * @return 0, -1 or 1
+ */
+static int PyIRIS2ODIMAPI_CompareWithASCIIString(PyObject* ptr, const char* name) {
+  int result = -1;
+  if (!PyString_Check(ptr)){
+#ifdef Py_USING_UNICODE
+    if (PyUnicode_Check(ptr)) {
+      PyObject* tmp = PyUnicode_AsEncodedString(ptr, NULL, NULL);
+      if (tmp != NULL) {
+        result = strcmp(PyString_AsString(tmp), name);
+        Py_DecRef(tmp);
+      }
+    }
+#endif
+  } else {
+	result = strcmp(PyString_AsString(ptr), name);
+  }
+  return result;
+}
+#endif

--- a/src/iris2list.c
+++ b/src/iris2list.c
@@ -30,9 +30,6 @@ along with RAVE.  If not, see <http://www.gnu.org/licenses/>.
 #include <unistd.h>
 #include <string.h> //strtok_s, memcpy
 #include <sys/types.h>
-#include <error.h>
-#include <argp.h>
-#include <argz.h>
 #include <time.h>
 #include "iris2odim.h" // this includes rave_alloc and other rave related
 #include "iris2list_listobj.h"

--- a/test/pytest/IRIS2ODIMTestSuite.py
+++ b/test/pytest/IRIS2ODIMTestSuite.py
@@ -1,5 +1,5 @@
 '''
-Copyright (C) 2017 The Crown (i.e. Her Majesty the Queen in Right of Canada)
+Copyright (C) 2021 The Crown (i.e. Her Majesty the Queen in Right of Canada)
 
 This file is an add-on to RAVE.
 
@@ -20,14 +20,36 @@ along with RAVE.  If not, see <http://www.gnu.org/licenses/>.
 Test suite for iris2odim
 
 @file
-@author Daniel Michelson, Environment and Climate Change Cananda
-@date 2017-08-25
+@author Peter Rodriguez, Environment and Climate Change Cananda
+@date 2021-02-24
 '''
-import unittest, os
+import unittest, os, sys
 import _rave
 
 from iris2odimTests import *
 
 
 if __name__ == '__main__':
-  unittest.main()
+#  unittest.main()
+
+  # do only this one test
+  suite = unittest.TestSuite()
+#  suite.addTest(iris2odimTest("testIsBadInput"))
+#  suite.addTest(iris2odimTest("testIsGoodInput"))
+#  suite.addTest(iris2odimTest("testReadScan"))
+#  suite.addTest(iris2odimTest("testReadPvol"))
+
+  # do all
+  suite = unittest.TestLoader().loadTestsFromTestCase(iris2odimTest)
+
+  #verbosity control added >=2.7
+  #".", "E" or "F" for "ok", "error" and "fail" written by self.AssertXXX method if verbose>=1
+  result = unittest.TextTestRunner(verbosity=3).run(suite)
+  #print('result : %s' % result)
+
+  #return an exit code
+  exit_code=int(not result.wasSuccessful())
+  #print('Exit code : %d' % exit_code)
+  sys.exit(exit_code)
+
+

--- a/test/pytest/iris2odimTests.py
+++ b/test/pytest/iris2odimTests.py
@@ -45,40 +45,40 @@ def validateAttributes(utest, obj, ref_obj):
                 utest.assertTrue(np.array_equal(attr, ref_attr))
             else:
                 #print aname, attr, ref_attr
-                utest.assertEquals(attr, ref_attr)
+                utest.assertEqual(attr, ref_attr)
 #        else: print aname
 
 def validateTopLevel(utest, obj, ref_obj):
-    utest.assertEquals(obj.source, ref_obj.source)
-    utest.assertEquals(obj.date , ref_obj.date)
-    utest.assertEquals(obj.time, ref_obj.time)
-    utest.assertAlmostEquals(obj.longitude, ref_obj.longitude, 12)
-    utest.assertAlmostEquals(obj.latitude, ref_obj.latitude, 12)
-    utest.assertAlmostEquals(obj.height, ref_obj.height, 12)
-    utest.assertAlmostEquals(obj.beamwidth, ref_obj.beamwidth, 12)
+    utest.assertEqual(obj.source, ref_obj.source)
+    utest.assertEqual(obj.date , ref_obj.date)
+    utest.assertEqual(obj.time, ref_obj.time)
+    utest.assertAlmostEqual(obj.longitude, ref_obj.longitude, 12)
+    utest.assertAlmostEqual(obj.latitude, ref_obj.latitude, 12)
+    utest.assertAlmostEqual(obj.height, ref_obj.height, 12)
+    utest.assertAlmostEqual(obj.beamwidth, ref_obj.beamwidth, 12)
     validateAttributes(utest, obj, ref_obj)
 
 
 def validateScan(utest, scan, ref_scan):
-    utest.assertEquals(scan.source, ref_scan.source)
-    utest.assertEquals(scan.date, ref_scan.date)
-    utest.assertEquals(scan.time, ref_scan.time)
-    utest.assertEquals(scan.startdate, ref_scan.startdate)
-    utest.assertEquals(scan.starttime, ref_scan.starttime)
-    utest.assertEquals(scan.enddate, ref_scan.enddate)
-    utest.assertEquals(scan.endtime, ref_scan.endtime)
-    utest.assertAlmostEquals(scan.longitude, ref_scan.longitude, 12)
-    utest.assertAlmostEquals(scan.latitude, ref_scan.latitude, 12)
-    utest.assertAlmostEquals(scan.height, ref_scan.height, 12)
-    utest.assertAlmostEquals(scan.beamwidth, ref_scan.beamwidth, 12)
-    utest.assertAlmostEquals(scan.elangle, ref_scan.elangle, 12)
-    utest.assertEquals(scan.nrays, ref_scan.nrays)
-    utest.assertEquals(scan.nbins, ref_scan.nbins)
-    utest.assertEquals(scan.a1gate, ref_scan.a1gate)
-    utest.assertEquals(scan.rscale, ref_scan.rscale)
-    utest.assertEquals(scan.rstart, ref_scan.rstart)
+    utest.assertEqual(scan.source, ref_scan.source)
+    utest.assertEqual(scan.date, ref_scan.date)
+    utest.assertEqual(scan.time, ref_scan.time)
+    utest.assertEqual(scan.startdate, ref_scan.startdate)
+    utest.assertEqual(scan.starttime, ref_scan.starttime)
+    utest.assertEqual(scan.enddate, ref_scan.enddate)
+    utest.assertEqual(scan.endtime, ref_scan.endtime)
+    utest.assertAlmostEqual(scan.longitude, ref_scan.longitude, 12)
+    utest.assertAlmostEqual(scan.latitude, ref_scan.latitude, 12)
+    utest.assertAlmostEqual(scan.height, ref_scan.height, 12)
+    utest.assertAlmostEqual(scan.beamwidth, ref_scan.beamwidth, 12)
+    utest.assertAlmostEqual(scan.elangle, ref_scan.elangle, 12)
+    utest.assertEqual(scan.nrays, ref_scan.nrays)
+    utest.assertEqual(scan.nbins, ref_scan.nbins)
+    utest.assertEqual(scan.a1gate, ref_scan.a1gate)
+    utest.assertEqual(scan.rscale, ref_scan.rscale)
+    utest.assertEqual(scan.rstart, ref_scan.rstart)
     for pname in ref_scan.getParameterNames():
-        utest.assertEquals(scan.hasParameter(pname), 
+        utest.assertEqual(scan.hasParameter(pname), 
                            ref_scan.hasParameter(pname))
         param = scan.getParameter(pname)
         ref_param = ref_scan.getParameter(pname)
@@ -122,7 +122,7 @@ class rb52odimTest(unittest.TestCase):
         self.assertTrue(new_rio.objectType is _rave.Rave_ObjectType_PVOL)
         pvol = new_rio.object
         ref_pvol = _raveio.open(self.REF_PVOL).object
-        self.assertEquals(pvol.getNumberOfScans(), ref_pvol.getNumberOfScans())
+        self.assertEqual(pvol.getNumberOfScans(), ref_pvol.getNumberOfScans())
         validateTopLevel(self, pvol, ref_pvol)
         for i in range(pvol.getNumberOfScans()):
             scan = pvol.getScan(i)

--- a/test/pytest/iris2odimTests.py
+++ b/test/pytest/iris2odimTests.py
@@ -104,7 +104,7 @@ def validateScan(utest, scan, ref_scan):
     validateAttributes(utest, scan, ref_scan)
 
 
-class rb52odimTest(unittest.TestCase):
+class iris2odimTest(unittest.TestCase):
     SCAN = '../WKR_201601201250_POLPPI.iri'
     PVOL = '../WKR_201601201250_CONVOL.iri'
     BAD = '../empty_file.nul'

--- a/test/pytest/iris2odimTests.py
+++ b/test/pytest/iris2odimTests.py
@@ -20,7 +20,7 @@ along with RAVE.  If not, see <http://www.gnu.org/licenses/>.
 iris2odim unit tests
 
 @file
-@author Daniel Michelson, Environment and Climate Change Cananda
+@author Daniel Michelson and Peter Rodriguez, Environment and Climate Change Cananda
 @date 2017-08-25
 '''
 import os, unittest
@@ -29,12 +29,19 @@ import _raveio
 import _iris2odim
 import numpy as np
 
-# Not needed because RAVE assigns these automagically
-IGNORE = ['what/version', 'what/object']
-
+# see http://git.baltrad.eu/git/?p=rave.git;a=blob_plain;f=modules/rave.c
+#_rave.setDebugLevel(_rave.Debug_RAVE_SPEWDEBUG)
+#_rave.setDebugLevel(_rave.Debug_RAVE_DEBUG)
+_rave.setDebugLevel(_rave.Debug_RAVE_WARNING) #turns off rave_hlhdf_utilities INFO : Adding group: how
 
 ## Helper functions for ODIM validation below. For some reason, unit test
 #  objects can't pass tests to methods, but they can be passed to functions.
+
+# Not needed because RAVE assigns these automagically, or they are just not relevant
+IGNORE = [
+    'what/version',
+    'what/object',
+    ]
 
 def validateAttributes(utest, obj, ref_obj):
     for aname in ref_obj.getAttributeNames():
@@ -43,10 +50,19 @@ def validateAttributes(utest, obj, ref_obj):
             ref_attr = ref_obj.getAttribute(aname)
             if isinstance(ref_attr, np.ndarray):  # Arrays get special treatment
                 utest.assertTrue(np.array_equal(attr, ref_attr))
+#                try: #nicer failure reporting
+#                    np.testing.assert_allclose(attr, ref_attr, rtol=1e-5, atol=0) #for no remake of ref files (numpy v1.16)
+#                except:
+#                    print('AssertionError: aname : '+aname)
             else:
-                #print aname, attr, ref_attr
-                utest.assertEqual(attr, ref_attr)
-#        else: print aname
+                try:
+                    utest.assertEqual(attr, ref_attr)
+                except AssertionError as e:
+                    print('AssertionError: aname : '+aname)
+                    print('ref_attr : ', ref_attr)
+                    print('    attr : ',     attr)
+#                    import pdb; pdb.set_trace()
+#                    utest.fail(str(e))
 
 def validateTopLevel(utest, obj, ref_obj):
     utest.assertEqual(obj.source, ref_obj.source)

--- a/tools/run_python_script.sh
+++ b/tools/run_python_script.sh
@@ -6,12 +6,13 @@
 # Author(s):   Anders Henja, Daniel Michelson
 #
 # Copyright:   Swedish Meteorological and Hydrological Institute, 2009
-#              The Crown (i.e. Her Majesty the Queen in Right of Canada), 2016
+#              The Crown (i.e. Her Majesty the Queen in Right of Canada), 2019
 #
 # History:  2009-10-22 Created by Anders Henja
-#			2016-06-10 Modified by Daniel Michelson for rave_ec
+#	    2016-06-10 Modified by Daniel Michelson for rave_ec
+#       2020-08-31 Peter Rodriguez, add PYTHON_BIN check 
 ############################################################
-SCRFILE=`python -c "import os;print os.path.abspath(\"$0\")"`
+SCRFILE=`python -c "import os;print(os.path.abspath(\"$0\"))"`
 SCRIPTPATH=`dirname "$SCRFILE"`
 
 DEF_MK_FILE="${RAVEROOT}/rave/mkf/def.mk"
@@ -23,6 +24,12 @@ fi
 
 RESULT=0
 
+# Identify python version
+PYTHON_BIN=`fgrep PYTHON_BIN "${DEF_MK_FILE}" | sed -e "s/\(PYTHON_BIN=[ \t]*\)//"`
+if [ "$PYTHON_BIN" = "" ]; then
+  PYTHON_BIN=python
+fi
+
 # RUN THE PYTHON TESTS
 HLHDF_MKFFILE=`fgrep HLHDF_HLDEF_MK_FILE "${DEF_MK_FILE}" | sed -e"s/\(HLHDF_HLDEF_MK_FILE=[ \t]*\)//"`
 
@@ -32,7 +39,7 @@ HDF5_LDPATH=`fgrep HDF5_LIBDIR "${HLHDF_MKFFILE}" | sed -e"s/\(HDF5_LIBDIR=[ \t]
 # Get HLHDFs libpath from raves mkf file
 HLHDF_LDPATH=`fgrep HLHDF_LIB_DIR "${DEF_MK_FILE}" | sed -e"s/\(HLHDF_LIB_DIR=[ \t]*\)//"`
 
-BNAME=`python -c 'from distutils import util; import sys; print "lib.%s-%s" % (util.get_platform(), sys.version[0:3])'`
+BNAME=`$PYTHON_BIN -c 'from distutils import util; import sys; print("lib.%s-%s" % (util.get_platform(), sys.version[0:3]))'`
 
 RBPATH="${SCRIPTPATH}/../Lib:${SCRIPTPATH}/../modules"
 EC_LDPATH="${SCRIPTPATH}/../src"
@@ -77,9 +84,9 @@ NARGS=$#
 PYSCRIPT=
 DIRNAME=
 if [ $NARGS -eq 1 ]; then
-  PYSCRIPT=`python -c "import os;print os.path.abspath(\"$1\")"`
+  PYSCRIPT=`$PYTHON_BIN -c "import os;print(os.path.abspath(\"$1\"))"`
 elif [ $NARGS -eq 2 ]; then
-  PYSCRIPT=`python -c "import os;print os.path.abspath(\"$1\")"`
+  PYSCRIPT=`$PYTHON_BIN -c "import os;print(os.path.abspath(\"$1\"))"`
   DIRNAME="$2"
 elif [ $NARGS -eq 0 ]; then
   # Do nothing
@@ -95,9 +102,9 @@ if [ "$DIRNAME" != "" ]; then
 fi
 
 if [ "$PYSCRIPT" != "" ]; then
-  python "$PYSCRIPT"
+  $PYTHON_BIN "$PYSCRIPT"
 else
-  python
+  $PYTHON_BIN
 fi
 
 VAL=$?
@@ -107,4 +114,3 @@ fi
 
 # EXIT WITH A STATUS CODE, 0 == OK, ANY OTHER VALUE = FAIL
 exit $RESULT
-


### PR DESCRIPTION
Commits list,
- run_python_script.sh now determining which PYTHON_BIN to use
- upgrade to use Python >2.6 and Python 3 compatibility file
- assert...Equals deprecated for assert...Equal
- Exit code = 1 if any tests fail. TestSuite can now select individual …
- Unittests debugging now consistent with rb52odim
- pytest class name incorrect, now iris2odimTest
- Remove extra unused includes for Mac OSX compatibility 